### PR TITLE
change: use setup-go action to install go before running CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,17 +26,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: './go.mod'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-
-      - uses: ./.github/actions/go-setup
-        with:
-          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
-      - run: make build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## What

Fix CodeQL tool error by setting up go before running CodeQL action

## Why

Tool is complaining here: https://github.com/greenbone/opensight-golang-libraries/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS6Y3PMRSXC3BOPFWWY

## References

https://github.com/actions/setup-go#basic
