### PR TITLE
Add team vulnerability-intelligence-maintainers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # default reviewers
-*                   @greenbone/asset
+*               @greenbone/asset @greenbone/vulnerability-intelligence-maintainers
 
 # .github
-.github/        @greenbone/asset @greenbone/devops
+.github/        @greenbone/asset @greenbone/vulnerability-intelligence-maintainers @greenbone/devops


### PR DESCRIPTION
## What

Add team vulnerability-intelligence-maintainers to CODEOWNERS

## Why

this is a cross-team repository


