### PR TITLE
Make `Encrypt` and `Decrypt` public functions

### DIFF
--- a/pkg/dbcrypt/config/config.go
+++ b/pkg/dbcrypt/config/config.go
@@ -18,15 +18,14 @@ type CryptoConfig struct {
 	// Contains the password for encrypting user group specific report encryptions using v1 to v2
 	ReportEncryptionV1Password string `validate:"required" viperEnv:"TASK_REPORT_CRYPTO_V1_PASSWORD"`
 	// Contains the salt for encrypting user group specific report encryptions v1 to v2
-	ReportEncryptionV1Salt string `validate:"required" viperEnv:"TASK_REPORT_CRYPTO_V1_SALT"`
+	ReportEncryptionV1Salt string `validate:"required,gte=32" viperEnv:"TASK_REPORT_CRYPTO_V1_SALT"`
 }
 
-func Read() CryptoConfig {
-	config := &CryptoConfig{}
-	_, err := configReader.ReadEnvVarsIntoStruct(config)
+func Read() (config CryptoConfig, err error) {
+	_, err = configReader.ReadEnvVarsIntoStruct(&config)
 	if err != nil {
-		log.Err(err)
+		return config, err
 	}
 	log.Debug().Msgf("CryptoConfig: %+v", config)
-	return *config
+	return config, nil
 }

--- a/pkg/dbcrypt/dbcrypt.go
+++ b/pkg/dbcrypt/dbcrypt.go
@@ -14,6 +14,8 @@ import (
 	"reflect"
 
 	"github.com/greenbone/opensight-golang-libraries/pkg/dbcrypt/config"
+
+	"github.com/rs/zerolog/log"
 )
 
 const prefix = "ENC:"
@@ -25,9 +27,13 @@ type DBCrypt[T any] struct {
 
 func (d *DBCrypt[T]) loadKey() []byte {
 	if d.config == (config.CryptoConfig{}) {
-		d.config = config.Read()
+		conf, err := config.Read()
+		if err != nil {
+			log.Fatal().Err(err).Msg("crypto config is invalid")
+		}
+		d.config = conf
 	}
-	key := []byte(d.config.ReportEncryptionV1Password + d.config.ReportEncryptionV1Salt)[:32] // Truncate or pad key to 32 bytes
+	key := []byte(d.config.ReportEncryptionV1Password + d.config.ReportEncryptionV1Salt)[:32] // Truncate key to 32 bytes
 	return key
 }
 

--- a/pkg/dbcrypt/dbcrypt_test.go
+++ b/pkg/dbcrypt/dbcrypt_test.go
@@ -80,13 +80,15 @@ func TestEncryptDecrypt(t *testing.T) {
 		Field1:   "111111111",
 		PwdField: "ThePassword",
 	}
+	var originalPw string = clearData.PwdField
 
 	cryptor := DBCrypt[MyTable]{}
 	err := cryptor.EncryptStruct(clearData)
 	require.NoError(t, err)
+	require.NotEqual(t, originalPw, clearData.PwdField, "password was not encrypted")
 	err = cryptor.DecryptStruct(clearData)
 	require.NoError(t, err)
-	assert.Equal(t, "ThePassword", clearData.PwdField)
+	assert.Equal(t, originalPw, clearData.PwdField)
 }
 
 func TestApplianceEncryption(t *testing.T) {

--- a/pkg/dbcrypt/dbcrypt_test.go
+++ b/pkg/dbcrypt/dbcrypt_test.go
@@ -70,7 +70,7 @@ func getTestDb(t *testing.T) *gorm.DB {
 
 func TestEncryptDecrypt(t *testing.T) {
 	os.Setenv("TASK_REPORT_CRYPTO_V1_PASSWORD", "my-key-1234567890")
-	os.Setenv("TASK_REPORT_CRYPTO_V1_SALT", "my-salt-0987654321")
+	os.Setenv("TASK_REPORT_CRYPTO_V1_SALT", "my-salt-0987654321-0987654321-09")
 	defer func() {
 		os.Unsetenv("TASK_REPORT_CRYPTO_V1_PASSWORD")
 		os.Unsetenv("TASK_REPORT_CRYPTO_V1_SALT")
@@ -93,7 +93,7 @@ func TestEncryptDecrypt(t *testing.T) {
 
 func TestApplianceEncryption(t *testing.T) {
 	os.Setenv("TASK_REPORT_CRYPTO_V1_PASSWORD", "my-key-1234567890")
-	os.Setenv("TASK_REPORT_CRYPTO_V1_SALT", "my-salt-0987654321")
+	os.Setenv("TASK_REPORT_CRYPTO_V1_SALT", "my-salt-0987654321-0987654321-09")
 	defer func() {
 		os.Unsetenv("TASK_REPORT_CRYPTO_V1_PASSWORD")
 		os.Unsetenv("TASK_REPORT_CRYPTO_V1_SALT")


### PR DESCRIPTION
## What

Make `Encrypt` and `Decrypt` public functions and require salt of minimum length of 32 characters.

## Why

We want to use `Encrypt` and `Decrypt` separately, as the usage within the `DBCrypt` struct has specific requirements like idempotency which don't apply in other cases and we want to use encryption with a different kind of config.

The salt length should be at least 32 byte, so that no matter the length of the password, we get a an encryption key with all 32 bytes set.

## References

Needed for VTI-50.


