### PR TITLE
change: upgrade go version to 1.22.1 to fix vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/greenbone/opensight-golang-libraries
 
-go 1.21
+go 1.22.1
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## What

Upgrade go version to 1.22.1 

## Why

To get rid of vulnerabilities from the go std library.