### PR TITLE
Adjust postgres query builder

### DIFF
--- a/pkg/postgres/query/builder.go
+++ b/pkg/postgres/query/builder.go
@@ -37,6 +37,8 @@ func NewPostgresQueryBuilder(querySetting *Settings) *Builder {
 
 // AddFilterRequest appends filter conditions to the query builder based on the provided filter request.
 // It constructs conditional clauses using the logic operator specified in the request.
+// TODO: Enhance the AddFilterRequest function to prevent SQL injection vulnerabilities.
+// AddFilterRequest is currently vulnerable to sql injection and should be used only when the input is trusted
 func (qb *Builder) AddFilterRequest(request *filter.Request) error {
 	if request == nil {
 		return errors.New("missing filter request, add filter request body or remove the call to AddFilterRequest()")
@@ -62,7 +64,7 @@ func (qb *Builder) AddFilterRequest(request *filter.Request) error {
 		if err != nil {
 			return fmt.Errorf("error composing query from filter field %w", err)
 		}
-		if index == len(request.Fields)-1 && len(request.Fields) != 1 {
+		if index > 0 {
 			qb.query.WriteString(fmt.Sprintf(" %s", logicOperator))
 		}
 		qb.query.WriteString(generateConditionalQuery(conditionParams, conditionTemplate))

--- a/pkg/postgres/query/builder.go
+++ b/pkg/postgres/query/builder.go
@@ -50,16 +50,15 @@ func (qb *Builder) AddFilterRequest(request *filter.Request) error {
 		var (
 			err               error
 			valueIsList       bool
-			valueList         []any
 			conditionTemplate string
 			conditionParams   []any
 		)
-		valueIsList, valueList, err = checkFieldValueType(field)
+		valueIsList, _, err = checkFieldValueType(field)
 		if err != nil {
 			return fmt.Errorf("error checking filter field value type '%s': %w", field, err)
 		}
 		conditionTemplate, conditionParams, err =
-			composeQuery(qb.querySettings.FilterFieldMapping, field, valueIsList, valueList)
+			composeQuery(qb.querySettings.FilterFieldMapping, field, valueIsList)
 		if err != nil {
 			return fmt.Errorf("error composing query from filter field %w", err)
 		}

--- a/pkg/postgres/query/builder.go
+++ b/pkg/postgres/query/builder.go
@@ -63,7 +63,7 @@ func (qb *Builder) AddFilterRequest(request *filter.Request) error {
 		if err != nil {
 			return fmt.Errorf("error composing query from filter field %w", err)
 		}
-		if index == len(request.Fields)-1 {
+		if index == len(request.Fields)-1 && len(request.Fields) != 1 {
 			qb.query.WriteString(fmt.Sprintf(" %s", logicOperator))
 		}
 		qb.query.WriteString(generateConditionalQuery(conditionParams, conditionTemplate))

--- a/pkg/postgres/query/builder_test.go
+++ b/pkg/postgres/query/builder_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 func TestQueryBuilder(t *testing.T) {
+	//field mapping from filter field to database col name
 	fieldMapping := map[string]string{
-		"status":             "status",
-		"source_id":          "source_id",
-		"other_filter_field": "corresponding_filter_field",
+		"status":             "status_col_name",
+		"source_id":          "source_id_col_name",
+		"other_filter_field": "other_filter_field_col_name",
 	}
 
 	tests := []struct {
@@ -53,7 +54,7 @@ func TestQueryBuilder(t *testing.T) {
 					SortDirection: "desc",
 				},
 			},
-			wantQuery: "WHERE \"status\" IN ('invalid status', 'valid status') OR \"source_id\" IN ('some_source_id', 'another_source_id', 'third_source_id') ORDER BY started DESC OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') ORDER BY started DESC OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with filter only",
@@ -74,7 +75,7 @@ func TestQueryBuilder(t *testing.T) {
 					Operator: filter.LogicOperatorAnd,
 				},
 			},
-			wantQuery: "WHERE \"status\" IN ('invalid status') AND \"source_id\" IN ('some_source_id')",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status') AND \"source_id_col_name\" IN ('some_source_id')",
 		},
 		{
 			name: "build query with filter and paging",
@@ -99,7 +100,7 @@ func TestQueryBuilder(t *testing.T) {
 					PageSize:  5,
 				},
 			},
-			wantQuery: "WHERE \"status\" IN ('invalid status') AND \"source_id\" IN ('some_source_id') OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status') AND \"source_id_col_name\" IN ('some_source_id') OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with just one filter and paging",
@@ -119,7 +120,7 @@ func TestQueryBuilder(t *testing.T) {
 					PageSize:  5,
 				},
 			},
-			wantQuery: "WHERE \"status\" IN ('invalid status') OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status') OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with just one filter with multiple values and paging",
@@ -139,7 +140,7 @@ func TestQueryBuilder(t *testing.T) {
 					PageSize:  5,
 				},
 			},
-			wantQuery: "WHERE \"status\" IN ('invalid status', 'another status') OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'another status') OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with more than two filter paging and sorting",
@@ -173,7 +174,7 @@ func TestQueryBuilder(t *testing.T) {
 					SortDirection: "desc",
 				},
 			},
-			wantQuery: "WHERE \"status\" IN ('invalid status', 'valid status') \"source_id\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"corresponding_filter_field\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with more than two filter paging and sorting",
@@ -207,7 +208,7 @@ func TestQueryBuilder(t *testing.T) {
 					SortDirection: "desc",
 				},
 			},
-			wantQuery: "WHERE \"status\" IN ('invalid status', 'valid status') \"source_id\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"corresponding_filter_field\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with just one filter with multiple values, compareOperatorNotEqualTo, and paging",
@@ -227,7 +228,7 @@ func TestQueryBuilder(t *testing.T) {
 					PageSize:  5,
 				},
 			},
-			wantQuery: "WHERE \"status\" NOT IN ('invalid status', 'another status') OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" NOT IN ('invalid status', 'another status') OFFSET 2 LIMIT 5",
 		},
 	}
 

--- a/pkg/postgres/query/builder_test.go
+++ b/pkg/postgres/query/builder_test.go
@@ -102,6 +102,46 @@ func TestQueryBuilder(t *testing.T) {
 			},
 			wantQuery: "WHERE \"status\" IN ('invalid status') AND \"source_id\" IN ('some_source_id') OFFSET 2 LIMIT 5",
 		},
+		{
+			name: "build query with just one filter and paging",
+			mockArg: query.ResultSelector{
+				Filter: &filter.Request{
+					Fields: []filter.RequestField{
+						{
+							Name:     "status",
+							Operator: filter.CompareOperatorIsEqualTo,
+							Value:    []any{"invalid status"},
+						},
+					},
+					Operator: filter.LogicOperatorOr,
+				},
+				Paging: &paging.Request{
+					PageIndex: 2,
+					PageSize:  5,
+				},
+			},
+			wantQuery: "WHERE \"status\" IN ('invalid status') OFFSET 2 LIMIT 5",
+		},
+		{
+			name: "build query with just one filter with multiple values and paging",
+			mockArg: query.ResultSelector{
+				Filter: &filter.Request{
+					Fields: []filter.RequestField{
+						{
+							Name:     "status",
+							Operator: filter.CompareOperatorIsEqualTo,
+							Value:    []any{"invalid status", "another status"},
+						},
+					},
+					Operator: filter.LogicOperatorOr,
+				},
+				Paging: &paging.Request{
+					PageIndex: 2,
+					PageSize:  5,
+				},
+			},
+			wantQuery: "WHERE \"status\" IN ('invalid status', 'another status') OFFSET 2 LIMIT 5",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/postgres/query/builder_test.go
+++ b/pkg/postgres/query/builder_test.go
@@ -209,6 +209,26 @@ func TestQueryBuilder(t *testing.T) {
 			},
 			wantQuery: "WHERE \"status\" IN ('invalid status', 'valid status') \"source_id\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"corresponding_filter_field\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
 		},
+		{
+			name: "build query with just one filter with multiple values, compareOperatorNotEqualTo, and paging",
+			mockArg: query.ResultSelector{
+				Filter: &filter.Request{
+					Fields: []filter.RequestField{
+						{
+							Name:     "status",
+							Operator: filter.CompareOperatorIsNotEqualTo,
+							Value:    []any{"invalid status", "another status"},
+						},
+					},
+					Operator: filter.LogicOperatorOr,
+				},
+				Paging: &paging.Request{
+					PageIndex: 2,
+					PageSize:  5,
+				},
+			},
+			wantQuery: "WHERE \"status\" NOT IN ('invalid status', 'another status') OFFSET 2 LIMIT 5",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/postgres/query/builder_test.go
+++ b/pkg/postgres/query/builder_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestQueryBuilder(t *testing.T) {
-	//field mapping from filter field to database col name
+	// field mapping from filter field to database col name
 	fieldMapping := map[string]string{
 		"status":             "status_col_name",
 		"source_id":          "source_id_col_name",
@@ -174,7 +174,7 @@ func TestQueryBuilder(t *testing.T) {
 					SortDirection: "desc",
 				},
 			},
-			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with more than two filter paging and sorting",
@@ -208,7 +208,7 @@ func TestQueryBuilder(t *testing.T) {
 					SortDirection: "desc",
 				},
 			},
-			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with just one filter with multiple values, compareOperatorNotEqualTo, and paging",

--- a/pkg/postgres/query/compose.go
+++ b/pkg/postgres/query/compose.go
@@ -15,76 +15,27 @@ func composeQuery(
 	fieldMapping map[string]string, // Mapping of field names to database column names
 	field filter.RequestField, // The filter request field containing the field name and operator
 	valueIsList bool, // Indicates if the value is a list
-	valueList []any, // List of values for comparison
 ) (
 	conditionTemplate string, // Template for the SQL condition
 	conditionParams []any, // Parameters for the SQL condition
 	err error, // Error encountered during execution
 ) {
+	// translate filter field to database column name if field mapping exists
+	if len(fieldMapping) != 0 {
+		dbColumnName, ok := fieldMapping[field.Name]
+		if ok {
+			field.Name = dbColumnName
+		}
+	}
+
 	switch field.Operator {
 	case filter.CompareOperatorIsEqualTo:
-		_, ok := fieldMapping[field.Name]
-		if ok {
-			conditionTemplate, conditionParams, err = simpleOperatorCondition(
-				field, valueIsList, "%s =", "%s IN",
-			)
-		} else {
-			conditionTemplate, conditionParams, err = likeOperatorCondition(
-				field, valueIsList, valueList, equalsAsLikePattern, false,
-			)
-		}
+		conditionTemplate, conditionParams, err = simpleOperatorCondition(
+			field, valueIsList, "%s =", "%s IN",
+		)
 	case filter.CompareOperatorIsNotEqualTo:
-		_, ok := fieldMapping[field.Name]
-		if ok {
-			conditionTemplate, conditionParams, err = simpleOperatorCondition(
-				field, valueIsList, "%s !=", "%s NOT IN",
-			)
-		} else {
-			conditionTemplate, conditionParams, err = likeOperatorCondition(
-				field, valueIsList, valueList, equalsAsLikePattern, true,
-			)
-		}
-	case filter.CompareOperatorIsLessThan:
 		conditionTemplate, conditionParams, err = simpleOperatorCondition(
-			field, valueIsList, "%s <", "%s < greatest",
-		)
-	case filter.CompareOperatorIsLessThanOrEqualTo:
-		conditionTemplate, conditionParams, err = simpleOperatorCondition(
-			field, valueIsList, "%s <=", "%s <= greatest",
-		)
-	case filter.CompareOperatorIsGreaterThan:
-		conditionTemplate, conditionParams, err = simpleOperatorCondition(
-			field, valueIsList, "%s >", "%s > least",
-		)
-	case filter.CompareOperatorIsGreaterThanOrEqualTo:
-		conditionTemplate, conditionParams, err = simpleOperatorCondition(
-			field, valueIsList, "%s >=", "%s >= least",
-		)
-	case filter.CompareOperatorContains:
-		conditionTemplate, conditionParams, err = likeOperatorCondition(
-			field, valueIsList, valueList, containsAsLikePattern, false,
-		)
-	case filter.CompareOperatorDoesNotContain:
-		conditionTemplate, conditionParams, err = likeOperatorCondition(
-			field, valueIsList, valueList, containsAsLikePattern, true,
-		)
-	case filter.CompareOperatorBeginsWith:
-		conditionTemplate, conditionParams, err = likeOperatorCondition(
-			field, valueIsList, valueList, beginsWithAsLikePattern, false,
-		)
-	case filter.CompareOperatorDoesNotBeginWith:
-		conditionTemplate, conditionParams, err = likeOperatorCondition(
-			field, valueIsList, valueList, beginsWithAsLikePattern, true,
-		)
-	case filter.CompareOperatorBeforeDate:
-		conditionTemplate, conditionParams, err = simpleSingleStringValueOperatorCondition(
-			field, valueIsList,
-			"date_trunc('day'::text, %s) < date_trunc('day'::text, ::timestamp)",
-		)
-	case filter.CompareOperatorAfterDate:
-		conditionTemplate, conditionParams, err = simpleSingleStringValueOperatorCondition(
-			field, valueIsList,
-			"date_trunc('day'::text, %s) > date_trunc('day'::text, ::timestamp)",
+			field, valueIsList, "%s !=", "%s NOT IN",
 		)
 	default:
 		err = errors.Errorf("field '%s' with unknown operator '%s'", field.Name, field.Operator)

--- a/pkg/postgres/query/compose.go
+++ b/pkg/postgres/query/compose.go
@@ -21,11 +21,12 @@ func composeQuery(
 	err error, // Error encountered during execution
 ) {
 	// translate filter field to database column name if field mapping exists
-	if len(fieldMapping) != 0 {
-		dbColumnName, ok := fieldMapping[field.Name]
-		if ok {
-			field.Name = dbColumnName
-		}
+	dbColumnName, ok := fieldMapping[field.Name]
+	if ok {
+		field.Name = dbColumnName
+	} else {
+		return "", nil, filter.NewInvalidFilterFieldError(
+			"Mapping for filter field '%s' is currently not implemented.", field.Name)
 	}
 
 	switch field.Operator {

--- a/pkg/postgres/query/query.go
+++ b/pkg/postgres/query/query.go
@@ -50,26 +50,6 @@ func simpleOperatorCondition(
 	return conditionTemplate, conditionParams, nil
 }
 
-func simpleSingleStringValueOperatorCondition(
-	field filter.RequestField, valueIsList bool, singleValueTemplate string,
-) (conditionTemplate string, conditionParams []any, err error) {
-	conditionParams = []any{field.Value}
-	if valueIsList {
-		err = errors.Errorf("operator '%s' does not support multi-select", field.Operator)
-		return "", nil, err
-	} else if _, ok := field.Value.(string); ok {
-		quotedName, err := getQuotedName(field.Name)
-		if err != nil {
-			return "", nil, errors.Wrap(err, "could not get quoted name")
-		}
-		conditionTemplate = fmt.Sprintf(singleValueTemplate, quotedName)
-	} else {
-		err = errors.Errorf("operator '%s' requires a string value", field.Operator)
-		return "", nil, err
-	}
-	return conditionTemplate, conditionParams, nil
-}
-
 func checkFieldValueType(field filter.RequestField) (valueIsList bool, valueList []any, err error) {
 	if reflect.TypeOf(field.Value).Kind() == reflect.Slice {
 		valueList, valueIsList = field.Value.([]any)

--- a/pkg/postgres/query/query_test.go
+++ b/pkg/postgres/query/query_test.go
@@ -1,0 +1,39 @@
+package query
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGetQuotedName(t *testing.T) {
+	tests := map[string]struct {
+		fieldName               string
+		expectedQuotedFieldName string
+		errMessage              string
+	}{
+		"shouldReturnEmptyValue": {fieldName: "", expectedQuotedFieldName: `""`},
+		"shouldReturnQuotedFields": {
+			fieldName:               "table.field",
+			expectedQuotedFieldName: `"table"."field"`,
+		},
+		"shouldReturnAnErrorWhenTableNameIsEmpty": {
+			fieldName:               ".field",
+			expectedQuotedFieldName: ``, errMessage: `table name can not be empty`,
+		},
+		"shouldReturnAnErrorWhenFieldNameIsEmpty": {
+			fieldName:  "table.",
+			errMessage: `field name can not be empty`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			quotedName, err := getQuotedName(tc.fieldName)
+			if tc.errMessage != "" {
+				require.ErrorContains(t, err, tc.errMessage)
+			}
+			assert.Equal(t, tc.expectedQuotedFieldName, quotedName)
+		})
+	}
+}


### PR DESCRIPTION
## What
- A bug was causing the `AddFilterRequest` function to incorrectly append the logic operator even when only one filter field was present.
- Remove `composeQuery` `switch cases` for compare operators that do not work as intended with postgres
- Add mapping to db col name
- Add more unit tests
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

Note: This postgres builder was initially intended to be used by the [asset-management-backend](https://github.com/greenbone/asset-management-backend/blob/a16fe53e3383ab3042917100f9305203062e2266/internal/gateways/database/postgres/query/databaseQuery.go#L169) that uses `gorm`, but seeing as the underlying conditional query string for [gorm](https://gorm.io/docs/query.html) is starkly different from raw SQL query string, we will in the future, work on making it compatible for gorm. 
To reduce the scope we will for now only implement the filter "equal" & "notEqual"

## Why
This fix ensures that the logic operator is only used when there are multiple filter fields, also maintaining the accuracy and integrity of our query builder. 
<!-- Describe why are these changes necessary? -->

## References
https://jira.greenbone.net/browse/VTI-145

## Checklist

- [x] Tests

