### PR TITLE
add: use filter field mapping for sort columns

### DIFF
--- a/pkg/postgres/query/builder.go
+++ b/pkg/postgres/query/builder.go
@@ -103,7 +103,14 @@ func (qb *Builder) AddSorting(sort *sorting.Request) error {
 	if sort == nil {
 		return errors.New("missing sorting fields, add sort request or remove call to AddSort()")
 	}
-	qb.query.WriteString(fmt.Sprintf(" ORDER BY %s %s", sort.SortColumn, sort.SortDirection))
+
+	// map fields to column
+	sortColumn, ok := qb.querySettings.FilterFieldMapping[sort.SortColumn]
+	if !ok {
+		return fmt.Errorf("mapping for sort column '%s' has not been implemented", sort.SortColumn)
+	}
+
+	qb.query.WriteString(fmt.Sprintf(" ORDER BY %s %s", sortColumn, sort.SortDirection))
 	return nil
 }
 

--- a/pkg/postgres/query/builder_test.go
+++ b/pkg/postgres/query/builder_test.go
@@ -20,6 +20,7 @@ func TestQueryBuilder(t *testing.T) {
 		"status":             "status_col_name",
 		"source_id":          "source_id_col_name",
 		"other_filter_field": "other_filter_field_col_name",
+		"started":            "started_col_name",
 	}
 
 	tests := []struct {
@@ -54,7 +55,7 @@ func TestQueryBuilder(t *testing.T) {
 					SortDirection: "desc",
 				},
 			},
-			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') ORDER BY started DESC OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') ORDER BY started_col_name DESC OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with filter only",
@@ -174,7 +175,7 @@ func TestQueryBuilder(t *testing.T) {
 					SortDirection: "desc",
 				},
 			},
-			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started_col_name DESC OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with more than two filter paging and sorting",
@@ -208,7 +209,7 @@ func TestQueryBuilder(t *testing.T) {
 					SortDirection: "desc",
 				},
 			},
-			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started DESC OFFSET 2 LIMIT 5",
+			wantQuery: "WHERE \"status_col_name\" IN ('invalid status', 'valid status') OR \"source_id_col_name\" IN ('some_source_id', 'another_source_id', 'third_source_id') OR \"other_filter_field_col_name\" IN ('some_field', 'another_field', 'third_field') ORDER BY started_col_name DESC OFFSET 2 LIMIT 5",
 		},
 		{
 			name: "build query with just one filter with multiple values, compareOperatorNotEqualTo, and paging",


### PR DESCRIPTION
## What
Implement filter field mapping to allow sorting based on corresponding database column names.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
By using filter field mapping, clients can seamlessly associate filter fields with their corresponding database column names, simplifying the sorting process for PostgreSQL queries on the client (Frontend) side
<!-- Describe why are these changes necessary? -->

## References
https://jira.greenbone.net/browse/VTI-144
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


