### PR TITLE
Add: Unit test for openSearchClient.GetResponseError

### DIFF
--- a/pkg/openSearch/openSearchClient/client.go
+++ b/pkg/openSearch/openSearchClient/client.go
@@ -174,7 +174,7 @@ func GetResponseError(statusCode int, responseString []byte, indexName string) e
 		}
 
 		if errorResponse.HasError {
-			return errors.Errorf("request error %v", errorResponse)
+			return errors.Errorf("request error %s", string(responseString))
 		}
 
 		return nil

--- a/pkg/openSearch/openSearchClient/client_test.go
+++ b/pkg/openSearch/openSearchClient/client_test.go
@@ -217,3 +217,91 @@ func searchAllVulnerabilities(c *assert.CollectT, client *Client) *SearchRespons
 	require.NoError(c, err)
 	return searchResponse
 }
+
+func TestGetResponseError(t *testing.T) {
+	//given
+	testCases := map[string]struct {
+		givenStatusCode      int
+		givenResponse        string
+		expectedErrorMessage *string
+	}{
+		"no error": {
+			givenStatusCode:      200,
+			givenResponse:        `{"took": 1, "errors": false, "items": []}`,
+			expectedErrorMessage: nil,
+		},
+		"broken json": {
+			givenStatusCode:      200,
+			givenResponse:        `{"error": {`,
+			expectedErrorMessage: strPtr(`expect " after {`),
+		},
+		"error in body": {
+			givenStatusCode:      200,
+			givenResponse:        `{"took": 1, "errors": true, "items": [{"index": {}}]}`,
+			expectedErrorMessage: strPtr(`{"took": 1, "errors": true, "items": [{"index": {}}]}`),
+		},
+		"index exists": {
+			givenStatusCode: 400,
+			givenResponse: `{
+  "error": {
+    "root_cause": [
+      {
+        "type": "resource_already_exists_exception",
+        "reason": "index [test/CafPswH_Q5mGXcKgBN3TNg] already exists",
+        "index": "test",
+        "index_uuid": "CafPswH_Q5mGXcKgBN3TNg"
+      }
+    ],
+    "type": "resource_already_exists_exception",
+    "reason": "index [test/CafPswH_Q5mGXcKgBN3TNg] already exists",
+    "index": "test",
+    "index_uuid": "CafPswH_Q5mGXcKgBN3TNg"
+  },
+  "status": 400
+}`,
+			expectedErrorMessage: strPtr(`Resource 'test' already exists`),
+		},
+		"bad request with broken json": {
+			givenStatusCode:      400,
+			givenResponse:        `{"error": {`,
+			expectedErrorMessage: strPtr(`openSearchClient.OpenSearchErrors.ReadString`),
+		},
+		"some other bad request": {
+			givenStatusCode: 400,
+			givenResponse: `{
+  "error": {
+    "type": "some_bad_request",
+    "reason": "some reason",
+    "index": "test",
+    "index_uuid": "CafPswH_Q5mGXcKgBN3TNg"
+  },
+  "status": 400
+}`,
+			expectedErrorMessage: strPtr(`some reason`),
+		},
+		"internal server error": {
+			givenStatusCode:      500,
+			givenResponse:        `some error message`,
+			expectedErrorMessage: strPtr(`some error message`),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// when
+			err := GetResponseError(tc.givenStatusCode, []byte(tc.givenResponse), indexName)
+
+			// then
+			if tc.expectedErrorMessage != nil {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), *tc.expectedErrorMessage)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## What

Add unit test for openSearchClient.GetResponseError

## Why

To show that the implementation works with real example responses from opensearch and make sure that the behavior of the function does not change in case we refactor it. Also for documentation purposes.

## References

--

## Checklist

- [x] Tests


