### PR TITLE
fix: return early when there is no content of filter fields

### DIFF
--- a/pkg/postgres/query/builder.go
+++ b/pkg/postgres/query/builder.go
@@ -40,13 +40,9 @@ func NewPostgresQueryBuilder(querySetting *Settings) *Builder {
 // TODO: Enhance the AddFilterRequest function to prevent SQL injection vulnerabilities.
 // AddFilterRequest is currently vulnerable to sql injection and should be used only when the input is trusted
 func (qb *Builder) AddFilterRequest(request *filter.Request) error {
-	if request == nil {
-		return errors.New("missing filter request, add filter request body or remove the call to AddFilterRequest()")
-	}
-	if len(request.Fields) == 0 {
+	if request == nil || len(request.Fields) == 0 {
 		return nil
 	}
-
 	logicOperator := strings.ToUpper(string(request.Operator))
 
 	qb.query.WriteString("WHERE")

--- a/pkg/postgres/query/builder.go
+++ b/pkg/postgres/query/builder.go
@@ -43,6 +43,9 @@ func (qb *Builder) AddFilterRequest(request *filter.Request) error {
 	if request == nil {
 		return errors.New("missing filter request, add filter request body or remove the call to AddFilterRequest()")
 	}
+	if len(request.Fields) == 0 {
+		return nil
+	}
 
 	logicOperator := strings.ToUpper(string(request.Operator))
 

--- a/pkg/postgres/query/builder_test.go
+++ b/pkg/postgres/query/builder_test.go
@@ -231,6 +231,24 @@ func TestQueryBuilder(t *testing.T) {
 			},
 			wantQuery: "WHERE \"status_col_name\" NOT IN ('invalid status', 'another status') OFFSET 2 LIMIT 5",
 		},
+		{
+			name: "build valid query without filter fields",
+			mockArg: query.ResultSelector{
+				Filter: &filter.Request{
+					Fields:   []filter.RequestField{},
+					Operator: filter.LogicOperatorAnd,
+				},
+				Paging: &paging.Request{
+					PageIndex: 3,
+					PageSize:  10,
+				},
+				Sorting: &sorting.Request{
+					SortColumn:    "started",
+					SortDirection: "asc",
+				},
+			},
+			wantQuery: " ORDER BY started_col_name ASC OFFSET 3 LIMIT 10",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/postgres/query/builder_test.go
+++ b/pkg/postgres/query/builder_test.go
@@ -249,6 +249,20 @@ func TestQueryBuilder(t *testing.T) {
 			},
 			wantQuery: " ORDER BY started_col_name ASC OFFSET 3 LIMIT 10",
 		},
+		{
+			name: "build valid query without filter object",
+			mockArg: query.ResultSelector{
+				Paging: &paging.Request{
+					PageIndex: 3,
+					PageSize:  10,
+				},
+				Sorting: &sorting.Request{
+					SortColumn:    "started",
+					SortDirection: "asc",
+				},
+			},
+			wantQuery: " ORDER BY started_col_name ASC OFFSET 3 LIMIT 10",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What
Return early and do not attempt to build conditional query if filter object is not empty but the filter fields are empty.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Invalid query string when there is an empty filter field
<!-- Describe why are these changes necessary? -->

## References
https://jira.greenbone.net/browse/VTI-145
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


