### PR TITLE
AT-1690: replace archived errors package in opensight-golang-libraries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/lib/pq v1.10.9
 	github.com/opensearch-project/opensearch-go/v4 v4.0.0
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/samber/lo v1.44.0
 	github.com/spf13/viper v1.19.0
@@ -76,6 +75,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/pkg/openSearch/openSearchClient/client.go
+++ b/pkg/openSearch/openSearchClient/client.go
@@ -15,7 +15,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -54,14 +53,14 @@ func (c *Client) Search(indexName string, requestBody []byte) (responseBody []by
 		},
 	)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	// Get the raw response body to return a byte array.
 	body := searchResponse.Inspect().Response.Body
 	result, err := io.ReadAll(body)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	log.Trace().Str("src", "opensearch").Msgf("search response - statusCode:'%d' json:'%s'",
@@ -114,7 +113,7 @@ func (c *Client) deleteByQuery(indexName string, requestBody []byte, isAsync boo
 		},
 	)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -138,7 +137,7 @@ func SerializeDocumentsForBulkUpdate[T any](indexName string, documents []T) ([]
 			indexName) + "\n")
 		documentJson, err := jsoniter.Marshal(document)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 		body.WriteString(string(documentJson) + "\n")
 	}
@@ -162,7 +161,7 @@ func (c *Client) BulkUpdate(indexName string, requestBody []byte) error {
 		},
 	)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil

--- a/pkg/openSearch/openSearchClient/error.go
+++ b/pkg/openSearch/openSearchClient/error.go
@@ -4,8 +4,6 @@
 
 package openSearchClient
 
-import "github.com/pkg/errors"
-
 type OpenSearchErrors struct {
 	Reasons []OpenSearchRootCause
 	Type    string
@@ -37,10 +35,6 @@ func NewOpenSearchError(message string) *OpenSearchError {
 	}
 }
 
-func NewOpenSearchErrorWithStack(message string) error {
-	return errors.WithStack(NewOpenSearchError(message))
-}
-
 // OpenSearchResourceAlreadyExists openSearch resource already exists
 type OpenSearchResourceAlreadyExists struct {
 	Message string
@@ -50,16 +44,6 @@ func (o *OpenSearchResourceAlreadyExists) Error() string {
 	return o.Message
 }
 
-func NewOpenSearchResourceAlreadyExists(message string) *OpenSearchResourceAlreadyExists {
-	return &OpenSearchResourceAlreadyExists{
-		Message: message,
-	}
-}
-
-func NewOpenSearchResourceAlreadyExistsWithStack(message string) error {
-	return errors.WithStack(NewOpenSearchResourceAlreadyExists(message))
-}
-
 // OpenSearchResourceNotFound openSearch resource already exists
 type OpenSearchResourceNotFound struct {
 	Message string
@@ -67,16 +51,6 @@ type OpenSearchResourceNotFound struct {
 
 func (o *OpenSearchResourceNotFound) Error() string {
 	return o.Message
-}
-
-func NewOpenSearchResourceNotFound(message string) *OpenSearchResourceNotFound {
-	return &OpenSearchResourceNotFound{
-		Message: message,
-	}
-}
-
-func NewOpenSearchResourceNotFoundWithStack(message string) error {
-	return errors.WithStack(NewOpenSearchResourceNotFound(message))
 }
 
 type IndexError struct {

--- a/pkg/openSearch/openSearchClient/indexFunctions.go
+++ b/pkg/openSearch/openSearchClient/indexFunctions.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -39,7 +38,7 @@ func (i *IndexFunction) CreateIndex(indexName string, indexSchema []byte) error 
 		// If the error is due to a lack of disk space or memory, we should log it as a warning
 		// see details in https://repost.aws/knowledge-center/opensearch-403-clusterblockexception
 		log.Err(err).Msgf("Error while creating index: please check disk space and memory usage")
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -57,13 +56,13 @@ func (i *IndexFunction) GetIndexes(pattern string) ([]string, error) {
 	)
 	if err != nil {
 		log.Debug().Msgf("Error while checking if index exists: %s", err)
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	body := response.Inspect().Response.Body
 	resultString, err := io.ReadAll(body)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	return indexNameSliceOf(resultString)
@@ -73,7 +72,7 @@ func indexNameSliceOf(resultString []byte) ([]string, error) {
 	indexMap := make(map[string]interface{})
 	err := json.Unmarshal(resultString, &indexMap)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	indexSlice := make([]string, 0, len(indexMap))
@@ -104,7 +103,7 @@ func (i *IndexFunction) IndexExists(indexName string) (bool, error) {
 		}
 
 		log.Debug().Msgf("Error while checking if index exists: %s", err)
-		return false, errors.WithStack(err)
+		return false, err
 	}
 
 	return true, nil
@@ -118,7 +117,7 @@ func (i *IndexFunction) DeleteIndex(indexName string) error {
 		},
 	)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -134,7 +133,7 @@ func (i *IndexFunction) CreateOrPutAlias(aliasName string, indexNames ...string)
 	)
 	if err != nil {
 		log.Debug().Msgf("Error while creating and putting alias: %s", err)
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -149,7 +148,7 @@ func (i *IndexFunction) DeleteAliasFromIndex(indexName string, aliasName string)
 		},
 	)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -169,7 +168,7 @@ func (i *IndexFunction) IndexHasAlias(indexNames []string, aliasNames []string) 
 		}
 
 		log.Debug().Msgf("Error while checking the index alias: %s", err)
-		return false, errors.WithStack(err)
+		return false, err
 	}
 
 	return true, nil
@@ -186,7 +185,7 @@ func (i *IndexFunction) AliasExists(aliasName string) (bool, error) {
 		if response != nil && response.Inspect().Response.StatusCode == http.StatusNotFound {
 			return false, nil
 		}
-		return false, errors.WithStack(err)
+		return false, err
 	}
 
 	if len(response.Aliases) == 0 {
@@ -207,7 +206,7 @@ func (i *IndexFunction) GetIndexesForAlias(aliasName string) ([]string, error) {
 		},
 	)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	for _, alias := range response.Aliases {

--- a/pkg/openSearch/openSearchClient/json.go
+++ b/pkg/openSearch/openSearchClient/json.go
@@ -10,9 +10,10 @@ import (
 	"time"
 	"unsafe"
 
+	"errors"
+
 	"github.com/go-playground/validator/v10"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 func InitializeJson(timeFormats []string) {
@@ -29,7 +30,7 @@ func InitializeJson(timeFormats []string) {
 		}
 
 		if err != nil {
-			iter.Error = errors.WithStack(err)
+			iter.Error = err
 			return
 		}
 	})
@@ -68,8 +69,9 @@ func validateStruct(v any) error {
 	}
 
 	var validationErrors validator.ValidationErrors
+
 	if errors.As(err, &validationErrors) {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -79,7 +81,7 @@ func validateStruct(v any) error {
 func UnmarshalWithoutValidation(data []byte, v any) error {
 	reportUpdatedEvent := v
 	if err := jsoniter.Unmarshal(data, &reportUpdatedEvent); err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	return nil
 }

--- a/pkg/openSearch/openSearchClient/response.go
+++ b/pkg/openSearch/openSearchClient/response.go
@@ -6,7 +6,6 @@ package openSearchClient
 
 import (
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
 )
 
 type SearchResponseHit[T any] struct {
@@ -37,7 +36,7 @@ func UnmarshalSearchResponse[T any](data []byte) (*SearchResponse[T], error) {
 	var results SearchResponse[T]
 
 	if err := jsoniter.Unmarshal(data, &results); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return &results, nil
 }

--- a/pkg/openSearch/openSearchClient/updateQueue.go
+++ b/pkg/openSearch/openSearchClient/updateQueue.go
@@ -8,12 +8,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"sync"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -93,12 +93,12 @@ func (q *UpdateQueue) Update(indexName string, requestBody []byte) ([]byte, erro
 
 	var responseMap map[string]interface{}
 	if err := json.Unmarshal(response.Body, &responseMap); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	if _, ok := responseMap["failures"]; ok {
 		if len(responseMap["failures"].([]interface{})) > 0 {
-			return response.Body, errors.Errorf("Update failed - even after retries: %s", string(response.Body))
+			return response.Body, fmt.Errorf("Update failed - even after retries: %s", string(response.Body))
 		}
 	}
 
@@ -164,5 +164,5 @@ func (q *UpdateQueue) update(indexName string, requestBody []byte) ([]byte, erro
 		return result, nil
 	}
 
-	return nil, errors.WithStack(err)
+	return nil, err
 }

--- a/pkg/openSearch/openSearchQuery/README.md
+++ b/pkg/openSearch/openSearchQuery/README.md
@@ -17,13 +17,13 @@ Query(q.Build()).
 MarshalJSON()
 
 if err != nil {
-    return nil, errors.WithStack(err)
+    return nil, err
 }
 
 responseBody, err := v.openSearchClient.Search(openSearchModels.VulnerabilityIndexName, request)
 
 if err != nil {
-    return nil, errors.WithStack(err)
+    return nil, err
 }
 ```
 

--- a/pkg/openSearch/openSearchQuery/boolQueryBuilder.go
+++ b/pkg/openSearch/openSearchQuery/boolQueryBuilder.go
@@ -5,9 +5,10 @@
 package openSearchQuery
 
 import (
+	"fmt"
+
 	"github.com/aquasecurity/esquery"
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/filter"
-	"github.com/pkg/errors"
 )
 
 // BoolQueryBuilder is a builder for an OpenSearch bool query.
@@ -164,7 +165,7 @@ func (q *BoolQueryBuilder) AddFilterRequest(request *filter.Request) error {
 
 	effectiveRequest, err := effectiveFilterFields(*request, q.querySettings.FilterFieldMapping)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	operatorMapping := q.createOperatorMapping()
@@ -173,7 +174,7 @@ func (q *BoolQueryBuilder) AddFilterRequest(request *filter.Request) error {
 		if handler, ok := operatorMapping[field.Operator]; ok {
 			handler(field.Name, field.Keys, field.Value)
 		} else {
-			return errors.Errorf("field '%s' with unknown operator '%s'", field.Name, field.Operator)
+			return fmt.Errorf("field '%s' with unknown operator '%s'", field.Name, field.Operator)
 		}
 	}
 	switch effectiveRequest.Operator {
@@ -199,7 +200,7 @@ func (q *BoolQueryBuilder) AddFilterRequest(request *filter.Request) error {
 		}
 		return nil
 	default:
-		return errors.Errorf("unknown operator '%s'", effectiveRequest.Operator)
+		return fmt.Errorf("unknown operator '%s'", effectiveRequest.Operator)
 	}
 }
 

--- a/pkg/openSearch/openSearchQuery/boolQueryBuilderTestHelper_test.go
+++ b/pkg/openSearch/openSearchQuery/boolQueryBuilderTestHelper_test.go
@@ -6,7 +6,6 @@ package openSearchQuery
 
 import (
 	"github.com/aquasecurity/esquery"
-	"github.com/pkg/errors"
 )
 
 // Aggregation is an interface for all aggregations that can be converted to an esquery.Aggregation.
@@ -59,7 +58,7 @@ func (q *testBoolQueryBuilderWrapper) toJson() (json string, err error) {
 	}
 
 	if err1 != nil {
-		return "", errors.WithStack(err1)
+		return "", err1
 	}
 	return string(jsonByte), nil
 }

--- a/pkg/openSearch/openSearchQuery/sort.go
+++ b/pkg/openSearch/openSearchQuery/sort.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/paging"
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/sorting"
-	"github.com/pkg/errors"
 
 	"github.com/aquasecurity/esquery"
 )
@@ -47,7 +46,7 @@ func AddOrder(aggregation *esquery.TermsAggregation, sortingRequest *sorting.Req
 	if sortingRequest != nil {
 		field, err := effectiveSortFieldOf(*sortingRequest)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 		return aggregation.Order(map[string]string{field.aggregationValue: sortingRequest.SortDirection.String()}), nil
 	}
@@ -61,7 +60,7 @@ func AddMaxAggForSorting(aggs []esquery.Aggregation, sortingRequest *sorting.Req
 
 	field, err := effectiveSortFieldOf(*sortingRequest)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	// refers to an existing aggregation that does not need to be created
@@ -84,12 +83,12 @@ func BucketSortAgg(sortingRequest *sorting.Request, pagingRequest *paging.Reques
 	if sortingRequest != nil {
 		field, err := effectiveSortFieldOf(*sortingRequest)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 
 		order, err := getOrder(sortingRequest)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 
 		sorting = map[string]interface{}{
@@ -117,7 +116,7 @@ func AddBucketSortAgg(aggs []esquery.Aggregation, sortingRequest *sorting.Reques
 ) ([]esquery.Aggregation, error) {
 	agg, err := BucketSortAgg(sortingRequest, pagingRequest)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	if agg == nil {

--- a/pkg/postgres/query/builder.go
+++ b/pkg/postgres/query/builder.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"strings"
 
+	"errors"
+
 	"github.com/greenbone/opensight-golang-libraries/pkg/query"
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/filter"
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/paging"
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/sorting"
-	"github.com/pkg/errors"
 )
 
 // Settings is a configuration struct used to customize the behavior of the query builder.

--- a/pkg/postgres/query/compose.go
+++ b/pkg/postgres/query/compose.go
@@ -5,8 +5,9 @@
 package query
 
 import (
+	"fmt"
+
 	"github.com/greenbone/opensight-golang-libraries/pkg/query/filter"
-	"github.com/pkg/errors"
 )
 
 // composeQuery takes a field mapping, a filter request field, a flag indicating whether the value is a list,
@@ -72,7 +73,7 @@ func composeQuery(
 			" date_trunc('day'::text, %s) > date_trunc('day'::text, ?::timestamp)",
 		)
 	default:
-		err = errors.Errorf("field '%s' with unknown operator '%s'", field.Name, field.Operator)
+		err = fmt.Errorf("field '%s' with unknown operator '%s'", field.Name, field.Operator)
 	}
 	return conditionTemplate, err
 }

--- a/pkg/query/filter/error.go
+++ b/pkg/query/filter/error.go
@@ -6,8 +6,6 @@ package filter
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 type ValidationError struct {
@@ -25,7 +23,7 @@ func NewValidationError(format string, value ...any) *ValidationError {
 }
 
 func NewValidationErrorWithStack(format string, value ...any) error {
-	return errors.WithStack(NewValidationError(format, value...))
+	return NewValidationError(format, value...)
 }
 
 type InvalidFilterFieldError struct {
@@ -37,9 +35,9 @@ func (i *InvalidFilterFieldError) Error() string {
 }
 
 func NewInvalidFilterFieldError(format string, value ...any) error {
-	return errors.WithStack(&InvalidFilterFieldError{
+	return &InvalidFilterFieldError{
 		message: fmt.Sprintf(format, value...),
-	})
+	}
 }
 
 type UuidValidationError struct {

--- a/pkg/query/filter/type_enum.go
+++ b/pkg/query/filter/type_enum.go
@@ -11,24 +11,19 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 const (
-
-	// AggregateMetricSum represents an aggregate metric of type sum.
+	// AggregateMetricSum is a AggregateMetric of type sum.
 	AggregateMetricSum AggregateMetric = "sum"
-
-	// AggregateMetricMin
+	// AggregateMetricMin is a AggregateMetric of type min.
 	AggregateMetricMin AggregateMetric = "min"
-
-	// AggregateMetricMax is a constant of type AggregateMetric that represents the maximum aggregation metric.
+	// AggregateMetricMax is a AggregateMetric of type max.
 	AggregateMetricMax AggregateMetric = "max"
-
-	// AggregateMetricAvg is a constant of type AggregateMetric representing the average aggregate metric.
+	// AggregateMetricAvg is a AggregateMetric of type avg.
 	AggregateMetricAvg AggregateMetric = "avg"
-
-	// AggregateMetricValueCount is a constant of type AggregateMetric with a value of "valueCount".
+	// AggregateMetricValueCount is a AggregateMetric of type valueCount.
 	AggregateMetricValueCount AggregateMetric = "valueCount"
 )
 

--- a/pkg/query/filter/validation.go
+++ b/pkg/query/filter/validation.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"errors"
+
 	"github.com/google/uuid"
 	"github.com/greenbone/opensight-golang-libraries/pkg/slices"
-	"github.com/pkg/errors"
 )
 
 // ValidateFilter validates the filter in the request

--- a/pkg/query/filter/validation_test.go
+++ b/pkg/query/filter/validation_test.go
@@ -5,7 +5,7 @@
 package filter
 
 import (
-	stderrors "errors"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,7 +85,7 @@ func TestRequestOptionValidation(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, validationError.Error(), "field 'optionNameOne' must be from type '[]string'")
 	})
 
@@ -103,7 +103,7 @@ func TestRequestOptionValidation(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, validationError.Error(), "field 'optionNameOne' can not have the operator 'invalidOperator'")
 	})
 
@@ -121,7 +121,7 @@ func TestRequestOptionValidation(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, validationError.Error(), "field 'optionNameOne' can not have the operator ''")
 	})
 
@@ -139,7 +139,7 @@ func TestRequestOptionValidation(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, validationError.Error(), "field name '' is invalid")
 	})
 
@@ -173,7 +173,7 @@ func TestRequestOptionValidation(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, "field name 'invalidName' is invalid", validationError.Error())
 	})
 
@@ -239,7 +239,7 @@ func TestCascadeRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, "field 'tag' must not be empty", validationError.Error())
 	})
 
@@ -258,7 +258,7 @@ func TestCascadeRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, "field 'tag' must not be empty", validationError.Error())
 	})
 
@@ -276,7 +276,7 @@ func TestCascadeRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, "field 'tag' must not be empty", validationError.Error())
 	})
 
@@ -295,7 +295,7 @@ func TestCascadeRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, "field 'tag' must not be empty", validationError.Error())
 	})
 
@@ -314,7 +314,7 @@ func TestCascadeRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, "field 'tag' number of keys must be 1", validationError.Error())
 	})
 
@@ -333,7 +333,7 @@ func TestCascadeRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, "for the field 'tag' the value must be 'yes' or 'no'", validationError.Error())
 	})
 
@@ -414,7 +414,7 @@ func TestEnumRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, validationError.Error(), "field 'optionName' can not have the value 'invalid'")
 	})
 }
@@ -458,7 +458,7 @@ func TestStringRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, validationError.Error(), "field 'optionName' must be from type 'string'")
 	})
 }
@@ -502,7 +502,7 @@ func TestIntegerRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, validationError.Error(), "field 'optionName' must be from type 'integer'")
 	})
 }
@@ -546,7 +546,7 @@ func TestFloatRequestOption(t *testing.T) {
 			},
 		}, requestOptions)
 		var validationError *ValidationError
-		assert.True(t, stderrors.As(err, &validationError))
+		assert.True(t, errors.As(err, &validationError))
 		assert.Equal(t, validationError.Error(), "field 'optionName' must be from type 'float'")
 	})
 }

--- a/pkg/query/paging/error.go
+++ b/pkg/query/paging/error.go
@@ -2,8 +2,6 @@ package paging
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 type Error struct {
@@ -15,7 +13,7 @@ func (e *Error) Error() string {
 }
 
 func NewPagingError(format string, value ...any) error {
-	return errors.WithStack(&Error{
+	return &Error{
 		Msg: fmt.Sprintf(format, value...),
-	})
+	}
 }

--- a/pkg/query/sorting/error.go
+++ b/pkg/query/sorting/error.go
@@ -2,8 +2,6 @@ package sorting
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 type Error struct {
@@ -15,7 +13,7 @@ func (e *Error) Error() string {
 }
 
 func NewSortingError(format string, value ...any) error {
-	return errors.WithStack(&Error{
+	return &Error{
 		Msg: fmt.Sprintf(format, value...),
-	})
+	}
 }

--- a/pkg/query/sorting/sorting.go
+++ b/pkg/query/sorting/sorting.go
@@ -1,7 +1,8 @@
 package sorting
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"gorm.io/gorm"
 )
 
@@ -105,7 +106,7 @@ func DetermineEffectiveSortingParams(model SortingSettingsInterface, sortingReq 
 	// If there is an error in the request for sorting, get the defaults and apply them.
 	sortingDefaults, pdErr := GetSortDefaults(model)
 	if pdErr != nil {
-		err := errors.Wrap(pdErr, "failed to get sorting defaults")
+		err := fmt.Errorf("failed to get sorting defaults: %w", pdErr)
 		sortingReq.SortColumn = ""
 		sortingReq.SortDirection = DirectionDescending
 		return paramsOf(*sortingReq), err


### PR DESCRIPTION
AT-1690: replace archived errors package in opensight-golang-libraries

## What

- Removes stack trace wrapping from errors.
- Errors are formatted and/or wrapped with `fmt` instead of `pkg/errors`.

NOTE: `pkg/errors` is still an indirect import since the following 3rd party packages depend on it:

```
github.com/testcontainers/testcontainers-go
github.com/docker/docker/api/types/registry
```

NOTE: The following functions did not have immediate references in any repositories under Greenbone, so they have been removed:

```
NewOpenSearchErrorWithStack
NewOpenSearchResourceAlreadyExists
NewOpenSearchResourceAlreadyExistsWithStack
NewOpenSearchResourceNotFound
NewOpenSearchResourceNotFoundWithStack
```

## Why

- `pkg/errors` is archived and stdlib provides the same functionality.
- Returning stack traces with errors is not likely the right place in a package.
- Sometimes errors providing stack traces were wrapped multiple times which would append multiple traces. 

## References

https://jira.greenbone.net/browse/AT-1690

## Checklist

- [X] Tests


