### PR TITLE
remove goprivate variable from go setup

### DIFF
--- a/.github/actions/go-setup/action.yaml
+++ b/.github/actions/go-setup/action.yaml
@@ -10,7 +10,3 @@ runs:
         cache: true
         cache-dependency-path: go.sum
         go-version-file: go.mod
-    - run: go mod download
-      shell: bash
-      env:
-        GOPRIVATE: github.com/greenbone


### PR DESCRIPTION
## What

Remove goprivate variable from go setup

## Why

We don't require access to any private go module.

