### PR TITLE
AT-2046 clear cached openid token if request unauthorized

### DIFF
--- a/pkg/openSearch/openSearchClient/authenticator_test.go
+++ b/pkg/openSearch/openSearchClient/authenticator_test.go
@@ -26,6 +26,10 @@ func (m *MockTokenReceiver) GetClientAccessToken(clientName, clientSecret string
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockTokenReceiver) ClearClientAccessToken() {
+	m.Called()
+}
+
 func TestGetAuthenticationMethod(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## What

clear cached openID token if request to opensearch fails with client error status

## Why

cached openID token can be invalid if fetched before keycloak initialization is fully completed

## References

AT-2045

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


