### PR TITLE
Change: remove level critical notification

### DIFF
--- a/pkg/notifications/README.md
+++ b/pkg/notifications/README.md
@@ -76,10 +76,9 @@ type Level string
 
 ```go
 const (
-    LevelInfo     Level = "info"
-    LevelWarning  Level = "warning"
-    LevelError    Level = "error"
-    LevelCritical Level = "critical"
+    LevelInfo    Level = "info"
+    LevelWarning Level = "warning"
+    LevelError   Level = "error"
 )
 ```
 

--- a/pkg/notifications/model.go
+++ b/pkg/notifications/model.go
@@ -34,10 +34,9 @@ type notificationModel struct {
 type Level string
 
 const (
-	LevelInfo     Level = "info"
-	LevelWarning  Level = "warning"
-	LevelError    Level = "error"
-	LevelCritical Level = "critical"
+	LevelInfo    Level = "info"
+	LevelWarning Level = "warning"
+	LevelError   Level = "error"
 )
 
 func toNotificationModel(n Notification) notificationModel {

--- a/pkg/openSearch/openSearchClient/README.md
+++ b/pkg/openSearch/openSearchClient/README.md
@@ -60,6 +60,7 @@ For further usage examples see ./client\_test.go.
   - [func \(c \*Client\) AsyncDeleteByQuery\(indexName string, requestBody \[\]byte\) error](<#Client.AsyncDeleteByQuery>)
   - [func \(c \*Client\) BulkUpdate\(indexName string, requestBody \[\]byte\) error](<#Client.BulkUpdate>)
   - [func \(c \*Client\) Close\(\)](<#Client.Close>)
+  - [func \(c \*Client\) CompositeAggStream\(indexName string, requestBody \[\]byte, ctx context.Context\) \(io.Reader, error\)](<#Client.CompositeAggStream>)
   - [func \(c \*Client\) Count\(indexName string, requestBody \[\]byte\) \(count int64, err error\)](<#Client.Count>)
   - [func \(c \*Client\) DeleteByQuery\(indexName string, requestBody \[\]byte\) error](<#Client.DeleteByQuery>)
   - [func \(c \*Client\) Search\(indexName string, requestBody \[\]byte\) \(responseBody \[\]byte, err error\)](<#Client.Search>)
@@ -155,7 +156,7 @@ NewOpenSearchProjectClient creates a new official OpenSearch client \(package gi
 ctx is the context to use for the connection. config is the configuration for the client.
 
 <a name="SerializeDocumentsForBulkUpdate"></a>
-## func [SerializeDocumentsForBulkUpdate](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L288>)
+## func [SerializeDocumentsForBulkUpdate](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L424>)
 
 ```go
 func SerializeDocumentsForBulkUpdate[T any](indexName string, documents []T) ([]byte, error)
@@ -273,7 +274,7 @@ NewClient creates a new OpenSearch client.
 openSearchProjectClient is the official OpenSearch client to wrap. Use NewOpenSearchProjectClient to create it. updateMaxRetries is the number of retries for update requests. updateRetryDelay is the delay between retries.
 
 <a name="Client.AsyncDeleteByQuery"></a>
-### func \(\*Client\) [AsyncDeleteByQuery](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L249>)
+### func \(\*Client\) [AsyncDeleteByQuery](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L385>)
 
 ```go
 func (c *Client) AsyncDeleteByQuery(indexName string, requestBody []byte) error
@@ -284,7 +285,7 @@ AsyncDeleteByQuery updates documents in the given index asynchronously. It does 
 indexName is the name of the index to delete from. requestBody is the request body to send to OpenSearch to identify the documents to be deleted.
 
 <a name="Client.BulkUpdate"></a>
-### func \(\*Client\) [BulkUpdate](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L313>)
+### func \(\*Client\) [BulkUpdate](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L449>)
 
 ```go
 func (c *Client) BulkUpdate(indexName string, requestBody []byte) error
@@ -295,13 +296,22 @@ BulkUpdate performs a bulk update in the given index. It returns an error in cas
 indexName is the name of the index to update. requestBody is the request body to send to OpenSearch specifying the bulk update.
 
 <a name="Client.Close"></a>
-### func \(\*Client\) [Close](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L332>)
+### func \(\*Client\) [Close](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L468>)
 
 ```go
 func (c *Client) Close()
 ```
 
 Close stops the underlying UpdateQueue allowing a graceful shutdown.
+
+<a name="Client.CompositeAggStream"></a>
+### func \(\*Client\) [CompositeAggStream](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L219>)
+
+```go
+func (c *Client) CompositeAggStream(indexName string, requestBody []byte, ctx context.Context) (io.Reader, error)
+```
+
+
 
 <a name="Client.Count"></a>
 ### func \(\*Client\) [Count](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L78>)
@@ -313,7 +323,7 @@ func (c *Client) Count(indexName string, requestBody []byte) (count int64, err e
 
 
 <a name="Client.DeleteByQuery"></a>
-### func \(\*Client\) [DeleteByQuery](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L259>)
+### func \(\*Client\) [DeleteByQuery](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L395>)
 
 ```go
 func (c *Client) DeleteByQuery(indexName string, requestBody []byte) error
@@ -344,7 +354,7 @@ func (c *Client) SearchStream(indexName string, requestBody []byte, scrollTimeou
 
 
 <a name="Client.Update"></a>
-### func \(\*Client\) [Update](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L239>)
+### func \(\*Client\) [Update](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/client.go#L375>)
 
 ```go
 func (c *Client) Update(indexName string, requestBody []byte) (responseBody []byte, err error)
@@ -355,7 +365,7 @@ Update updates documents in the given index using UpdateQueue \(which is also pa
 indexName is the name of the index to update. requestBody is the request body to send to OpenSearch specifying the update.
 
 <a name="CountReq"></a>
-## type [CountReq](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L13-L18>)
+## type [CountReq](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L17-L22>)
 
 
 
@@ -369,7 +379,7 @@ type CountReq struct {
 ```
 
 <a name="CountReq.GetRequest"></a>
-### func \(CountReq\) [GetRequest](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L21>)
+### func \(CountReq\) [GetRequest](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L25>)
 
 ```go
 func (r CountReq) GetRequest() (*http.Request, error)
@@ -378,7 +388,7 @@ func (r CountReq) GetRequest() (*http.Request, error)
 GetRequest returns the \*http.Request that gets executed by the client
 
 <a name="CountResp"></a>
-## type [CountResp](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L41-L44>)
+## type [CountResp](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L45-L48>)
 
 
 
@@ -390,7 +400,7 @@ type CountResp struct {
 ```
 
 <a name="CountResp.Inspect"></a>
-### func \(CountResp\) [Inspect](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L53>)
+### func \(CountResp\) [Inspect](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L57>)
 
 ```go
 func (r CountResp) Inspect() opensearchapi.Inspect
@@ -902,7 +912,7 @@ type SearchResponseHitsTotal struct {
 ```
 
 <a name="ShardStats"></a>
-## type [ShardStats](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L46-L51>)
+## type [ShardStats](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchClient/count.go#L50-L55>)
 
 
 


### PR DESCRIPTION
## What

Remove level critical notification, as it was removed from [notification-service](https://github.com/greenbone/opensight-notification-service/pull/51)

## Why

It's not used.

## References

VTI-425

