### PR TITLE
add: opensearch query builder - text contains operator (full text search)

### DIFF
--- a/pkg/openSearch/openSearchQuery/README.md
+++ b/pkg/openSearch/openSearchQuery/README.md
@@ -48,14 +48,22 @@ Package openSearchQuery provides a query builder for OpenSearch.
 - [func AddOrder\(aggregation \*esquery.TermsAggregation, sortingRequest \*sorting.Request\) \(\*esquery.TermsAggregation, error\)](<#AddOrder>)
 - [func BucketSortAgg\(sortingRequest \*sorting.Request, pagingRequest \*paging.Request\) \(\*esquery.CustomAggMap, error\)](<#BucketSortAgg>)
 - [func HandleCompareOperatorBeginsWith\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorBeginsWith>)
+- [func HandleCompareOperatorBetweenDates\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorBetweenDates>)
 - [func HandleCompareOperatorContains\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorContains>)
 - [func HandleCompareOperatorIsEqualTo\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsEqualTo>)
+- [func HandleCompareOperatorIsEqualToRating\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsEqualToRating>)
 - [func HandleCompareOperatorIsGreaterThan\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsGreaterThan>)
 - [func HandleCompareOperatorIsGreaterThanOrEqualTo\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsGreaterThanOrEqualTo>)
+- [func HandleCompareOperatorIsGreaterThanOrEqualToRating\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsGreaterThanOrEqualToRating>)
+- [func HandleCompareOperatorIsGreaterThanRating\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsGreaterThanRating>)
 - [func HandleCompareOperatorIsKeywordEqualTo\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsKeywordEqualTo>)
 - [func HandleCompareOperatorIsLessThan\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsLessThan>)
 - [func HandleCompareOperatorIsLessThanOrEqualTo\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsLessThanOrEqualTo>)
+- [func HandleCompareOperatorIsLessThanOrEqualToRating\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsLessThanOrEqualToRating>)
+- [func HandleCompareOperatorIsLessThanRating\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsLessThanRating>)
+- [func HandleCompareOperatorIsNotEqualToRating\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorIsNotEqualToRating>)
 - [func HandleCompareOperatorNotBeginsWith\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorNotBeginsWith>)
+- [func HandleCompareOperatorTextContains\(fieldName string, fieldKeys \[\]string, fieldValue any, querySettings \*QuerySettings\) esquery.Mappable](<#HandleCompareOperatorTextContains>)
 - [func ValueToString\(value interface\{\}\) string](<#ValueToString>)
 - [type BoolQueryBuilder](<#BoolQueryBuilder>)
   - [func NewBoolQueryBuilder\(querySettings \*QuerySettings\) \*BoolQueryBuilder](<#NewBoolQueryBuilder>)
@@ -70,6 +78,7 @@ Package openSearchQuery provides a query builder for OpenSearch.
 - [type CompareOperatorHandler](<#CompareOperatorHandler>)
 - [type NestedQueryFieldDefinition](<#NestedQueryFieldDefinition>)
 - [type QuerySettings](<#QuerySettings>)
+- [type RatingRange](<#RatingRange>)
 
 
 <a name="AddBucketSortAgg"></a>
@@ -109,7 +118,7 @@ func BucketSortAgg(sortingRequest *sorting.Request, pagingRequest *paging.Reques
 BucketSortAgg is capable to sort all existing buckets, but is currently only used for paging
 
 <a name="HandleCompareOperatorBeginsWith"></a>
-## func [HandleCompareOperatorBeginsWith](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L80>)
+## func [HandleCompareOperatorBeginsWith](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L101>)
 
 ```go
 func HandleCompareOperatorBeginsWith(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
@@ -117,17 +126,30 @@ func HandleCompareOperatorBeginsWith(fieldName string, fieldKeys []string, field
 
 HandleCompareOperatorBeginsWith handles begins with
 
+<a name="HandleCompareOperatorBetweenDates"></a>
+## func [HandleCompareOperatorBetweenDates](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L307>)
+
+```go
+func HandleCompareOperatorBetweenDates(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
+```
+
+HandleCompareOperatorBetweenDates constructs an OpenSearch range query for a given date field. It accepts a field name and a field value, which must be either: \- A slice of two time.Time values \(\[\]time.Time\), representing the start and end of the range, or \- A slice of two RFC3339Nano\-formatted strings \(\[\]string\), which are parsed into time.Time, representing the start and end of the range.
+
+The generated range query is inclusive of both the lower and upper bounds. If a document’s timestamp is exactly equal to the start or end date, it will still match the query.
+
+If the slice length is not exactly 2, or if the string values cannot be parsed into valid dates, the function logs an error and returns an empty query \(MatchNone\).
+
 <a name="HandleCompareOperatorContains"></a>
-## func [HandleCompareOperatorContains](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L28>)
+## func [HandleCompareOperatorContains](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L33>)
 
 ```go
 func HandleCompareOperatorContains(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
 ```
 
-HandleCompareOperatorContains handles contains
+HandleCompareOperatorContains handles contains. In the index mapping the given field must be a string of type \`keyword\`.
 
 <a name="HandleCompareOperatorIsEqualTo"></a>
-## func [HandleCompareOperatorIsEqualTo](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L18>)
+## func [HandleCompareOperatorIsEqualTo](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L22>)
 
 ```go
 func HandleCompareOperatorIsEqualTo(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
@@ -135,8 +157,17 @@ func HandleCompareOperatorIsEqualTo(fieldName string, fieldKeys []string, fieldV
 
 HandleCompareOperatorIsEqualTo handles is equal to
 
+<a name="HandleCompareOperatorIsEqualToRating"></a>
+## func [HandleCompareOperatorIsEqualToRating](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L239>)
+
+```go
+func HandleCompareOperatorIsEqualToRating(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
+```
+
+
+
 <a name="HandleCompareOperatorIsGreaterThan"></a>
-## func [HandleCompareOperatorIsGreaterThan](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L138>)
+## func [HandleCompareOperatorIsGreaterThan](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L159>)
 
 ```go
 func HandleCompareOperatorIsGreaterThan(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
@@ -145,7 +176,7 @@ func HandleCompareOperatorIsGreaterThan(fieldName string, fieldKeys []string, fi
 HandleCompareOperatorIsGreaterThan handles is greater than
 
 <a name="HandleCompareOperatorIsGreaterThanOrEqualTo"></a>
-## func [HandleCompareOperatorIsGreaterThanOrEqualTo](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L130-L132>)
+## func [HandleCompareOperatorIsGreaterThanOrEqualTo](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L151-L153>)
 
 ```go
 func HandleCompareOperatorIsGreaterThanOrEqualTo(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
@@ -153,8 +184,26 @@ func HandleCompareOperatorIsGreaterThanOrEqualTo(fieldName string, fieldKeys []s
 
 HandleCompareOperatorIsGreaterThanOrEqualTo handles is greater than or equal to
 
+<a name="HandleCompareOperatorIsGreaterThanOrEqualToRating"></a>
+## func [HandleCompareOperatorIsGreaterThanOrEqualToRating](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L223-L225>)
+
+```go
+func HandleCompareOperatorIsGreaterThanOrEqualToRating(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
+```
+
+
+
+<a name="HandleCompareOperatorIsGreaterThanRating"></a>
+## func [HandleCompareOperatorIsGreaterThanRating](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L211>)
+
+```go
+func HandleCompareOperatorIsGreaterThanRating(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
+```
+
+
+
 <a name="HandleCompareOperatorIsKeywordEqualTo"></a>
-## func [HandleCompareOperatorIsKeywordEqualTo](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L23>)
+## func [HandleCompareOperatorIsKeywordEqualTo](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L27>)
 
 ```go
 func HandleCompareOperatorIsKeywordEqualTo(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
@@ -163,7 +212,7 @@ func HandleCompareOperatorIsKeywordEqualTo(fieldName string, fieldKeys []string,
 HandleCompareOperatorIsKeywordEqualTo handles is keyword field equal to
 
 <a name="HandleCompareOperatorIsLessThan"></a>
-## func [HandleCompareOperatorIsLessThan](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L144>)
+## func [HandleCompareOperatorIsLessThan](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L165>)
 
 ```go
 func HandleCompareOperatorIsLessThan(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
@@ -172,7 +221,7 @@ func HandleCompareOperatorIsLessThan(fieldName string, fieldKeys []string, field
 HandleCompareOperatorIsLessThan handles is less than
 
 <a name="HandleCompareOperatorIsLessThanOrEqualTo"></a>
-## func [HandleCompareOperatorIsLessThanOrEqualTo](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L124>)
+## func [HandleCompareOperatorIsLessThanOrEqualTo](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L145>)
 
 ```go
 func HandleCompareOperatorIsLessThanOrEqualTo(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
@@ -180,8 +229,35 @@ func HandleCompareOperatorIsLessThanOrEqualTo(fieldName string, fieldKeys []stri
 
 HandleCompareOperatorIsLessThanOrEqualTo handles is less than or equal to
 
+<a name="HandleCompareOperatorIsLessThanOrEqualToRating"></a>
+## func [HandleCompareOperatorIsLessThanOrEqualToRating](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L231-L233>)
+
+```go
+func HandleCompareOperatorIsLessThanOrEqualToRating(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
+```
+
+
+
+<a name="HandleCompareOperatorIsLessThanRating"></a>
+## func [HandleCompareOperatorIsLessThanRating](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L217>)
+
+```go
+func HandleCompareOperatorIsLessThanRating(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
+```
+
+
+
+<a name="HandleCompareOperatorIsNotEqualToRating"></a>
+## func [HandleCompareOperatorIsNotEqualToRating](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L247>)
+
+```go
+func HandleCompareOperatorIsNotEqualToRating(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
+```
+
+
+
 <a name="HandleCompareOperatorNotBeginsWith"></a>
-## func [HandleCompareOperatorNotBeginsWith](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L109>)
+## func [HandleCompareOperatorNotBeginsWith](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L130>)
 
 ```go
 func HandleCompareOperatorNotBeginsWith(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
@@ -189,14 +265,23 @@ func HandleCompareOperatorNotBeginsWith(fieldName string, fieldKeys []string, fi
 
 HandleCompareOperatorNotBeginsWith handles not begins with
 
+<a name="HandleCompareOperatorTextContains"></a>
+## func [HandleCompareOperatorTextContains](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L86>)
+
+```go
+func HandleCompareOperatorTextContains(fieldName string, fieldKeys []string, fieldValue any, querySettings *QuerySettings) esquery.Mappable
+```
+
+HandleCompareOperatorTextContains performs a full text search on the given field. In the index mapping it must be a string of type \`text\`.
+
 <a name="ValueToString"></a>
-## func [ValueToString](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L190>)
+## func [ValueToString](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/compareHandler.go#L259>)
 
 ```go
 func ValueToString(value interface{}) string
 ```
 
-
+ValueToString converts the given value to a string. Compared to [fmt.Sprint](<https://pkg.go.dev/fmt/#Sprint>) it will give RFC3339 format for [time.Time](<https://pkg.go.dev/time/#Time>) value and a specific formatting of numbers.
 
 <a name="BoolQueryBuilder"></a>
 ## type [BoolQueryBuilder](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L16-L22>)
@@ -212,7 +297,7 @@ type BoolQueryBuilder struct {
 ```
 
 <a name="NewBoolQueryBuilder"></a>
-### func [NewBoolQueryBuilder](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L73>)
+### func [NewBoolQueryBuilder](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L81>)
 
 ```go
 func NewBoolQueryBuilder(querySettings *QuerySettings) *BoolQueryBuilder
@@ -223,7 +308,7 @@ NewBoolQueryBuilder creates a new BoolQueryBuilder and returns it. It uses the d
 querySettings is used to configure the query builder.
 
 <a name="NewBoolQueryBuilderWith"></a>
-### func [NewBoolQueryBuilderWith](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L81>)
+### func [NewBoolQueryBuilderWith](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L89>)
 
 ```go
 func NewBoolQueryBuilderWith(query *esquery.BoolQuery, querySettings *QuerySettings) *BoolQueryBuilder
@@ -234,7 +319,7 @@ NewBoolQueryBuilderWith creates a new BoolQueryBuilder and returns it. It uses t
 query is the initial bool query to use. querySettings is used to configure the query builder.
 
 <a name="BoolQueryBuilder.AddCompareOperators"></a>
-### func \(\*BoolQueryBuilder\) [AddCompareOperators](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L100>)
+### func \(\*BoolQueryBuilder\) [AddCompareOperators](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L108>)
 
 ```go
 func (q *BoolQueryBuilder) AddCompareOperators(operators ...CompareOperator) *BoolQueryBuilder
@@ -245,7 +330,7 @@ AddCompareOperators adds the given set of CompareOperator to the set of CompareO
 operators is the set of CompareOperator to add.
 
 <a name="BoolQueryBuilder.AddFilterRequest"></a>
-### func \(\*BoolQueryBuilder\) [AddFilterRequest](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L154>)
+### func \(\*BoolQueryBuilder\) [AddFilterRequest](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L162>)
 
 ```go
 func (q *BoolQueryBuilder) AddFilterRequest(request *filter.Request) error
@@ -254,7 +339,7 @@ func (q *BoolQueryBuilder) AddFilterRequest(request *filter.Request) error
 AddFilterRequest adds a filter request to this query. The filter request is translated into a bool query.
 
 <a name="BoolQueryBuilder.AddTermFilter"></a>
-### func \(\*BoolQueryBuilder\) [AddTermFilter](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L116>)
+### func \(\*BoolQueryBuilder\) [AddTermFilter](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L124>)
 
 ```go
 func (q *BoolQueryBuilder) AddTermFilter(fieldName string, value interface{}) *BoolQueryBuilder
@@ -265,7 +350,7 @@ AddTermFilter adds a term filter to this query.
 value is the value to filter for.
 
 <a name="BoolQueryBuilder.AddTermsFilter"></a>
-### func \(\*BoolQueryBuilder\) [AddTermsFilter](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L108>)
+### func \(\*BoolQueryBuilder\) [AddTermsFilter](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L116>)
 
 ```go
 func (q *BoolQueryBuilder) AddTermsFilter(fieldName string, values ...interface{}) *BoolQueryBuilder
@@ -276,7 +361,7 @@ AddTermsFilter adds a terms filter to this query.
 values is the list of values to filter for.
 
 <a name="BoolQueryBuilder.Build"></a>
-### func \(\*BoolQueryBuilder\) [Build](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L231>)
+### func \(\*BoolQueryBuilder\) [Build](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L239>)
 
 ```go
 func (q *BoolQueryBuilder) Build() *esquery.BoolQuery
@@ -285,7 +370,7 @@ func (q *BoolQueryBuilder) Build() *esquery.BoolQuery
 Build returns the built query.
 
 <a name="BoolQueryBuilder.ReplaceCompareOperators"></a>
-### func \(\*BoolQueryBuilder\) [ReplaceCompareOperators](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L92>)
+### func \(\*BoolQueryBuilder\) [ReplaceCompareOperators](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L100>)
 
 ```go
 func (q *BoolQueryBuilder) ReplaceCompareOperators(operators []CompareOperator) *BoolQueryBuilder
@@ -296,7 +381,7 @@ ReplaceCompareOperators replaces the set of CompareOperator to be used for this 
 operators is the new set of CompareOperator to use.
 
 <a name="CompareOperator"></a>
-## type [CompareOperator](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L63-L68>)
+## type [CompareOperator](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L71-L76>)
 
 CompareOperator defines a mapping between a filter.CompareOperator and a function to generate an appropriate query condition in from of a CompareOperatorHandler.
 
@@ -322,7 +407,7 @@ type CompareOperatorHandler func(fieldName string, fieldKeys []string, fieldValu
 ```
 
 <a name="NestedQueryFieldDefinition"></a>
-## type [NestedQueryFieldDefinition](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L52-L59>)
+## type [NestedQueryFieldDefinition](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L60-L67>)
 
 NestedQueryFieldDefinition is a definition of a nested query field.
 
@@ -338,7 +423,7 @@ type NestedQueryFieldDefinition struct {
 ```
 
 <a name="QuerySettings"></a>
-## type [QuerySettings](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L37-L49>)
+## type [QuerySettings](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L43-L57>)
 
 QuerySettings is used to configure the query builder.
 
@@ -355,6 +440,20 @@ type QuerySettings struct {
     // UseMatchPhraseFields is a map of field names to a boolean value indicating whether the field should use a match phrase query.
     UseMatchPhrase     map[string]bool
     FilterFieldMapping map[string]string
+    // StringFieldRating is a map for field names with a rating. The rating is used to determine the compare order of the field in the query.
+    StringFieldRating map[string]map[string]RatingRange
+}
+```
+
+<a name="RatingRange"></a>
+## type [RatingRange](<https://github.com/greenbone/opensight-golang-libraries/blob/main/pkg/openSearch/openSearchQuery/boolQueryBuilder.go#L37-L40>)
+
+RatingRange represent a closed interval of float32 values.
+
+```go
+type RatingRange struct {
+    Min float32 // Lower bound of the rating range (inclusive)
+    Max float32 // Upper bound of the rating range (inclusive)
 }
 ```
 

--- a/pkg/openSearch/openSearchQuery/boolQueryBuilder.go
+++ b/pkg/openSearch/openSearchQuery/boolQueryBuilder.go
@@ -271,6 +271,7 @@ func defaultCompareOperators() []CompareOperator {
 			Operator: filter.CompareOperatorIsGreaterThanOrEqualTo,
 			Handler:  HandleCompareOperatorIsGreaterThanOrEqualTo, MustCondition: true,
 		},
+		{Operator: filter.CompareOperatorTextContains, Handler: HandleCompareOperatorTextContains, MustCondition: true},
 		{Operator: filter.CompareOperatorIsGreaterThan, Handler: HandleCompareOperatorIsGreaterThan, MustCondition: true},
 		{Operator: filter.CompareOperatorIsLessThan, Handler: HandleCompareOperatorIsLessThan, MustCondition: true},
 		{Operator: filter.CompareOperatorAfterDate, Handler: HandleCompareOperatorIsGreaterThan, MustCondition: true},

--- a/pkg/query/filter/type.go
+++ b/pkg/query/filter/type.go
@@ -40,6 +40,8 @@ CompareOperator ENUM(
 				contains
 				doesNotContain
 
+				textContains
+
 				isNumberEqualTo
 				isEqualTo
 				isIpEqualTo

--- a/pkg/query/filter/type_enum.go
+++ b/pkg/query/filter/type_enum.go
@@ -139,6 +139,8 @@ const (
 	CompareOperatorContains CompareOperator = "contains"
 	// CompareOperatorDoesNotContain is a CompareOperator of type doesNotContain.
 	CompareOperatorDoesNotContain CompareOperator = "doesNotContain"
+	// CompareOperatorTextContains is a CompareOperator of type textContains.
+	CompareOperatorTextContains CompareOperator = "textContains"
 	// CompareOperatorIsNumberEqualTo is a CompareOperator of type isNumberEqualTo.
 	CompareOperatorIsNumberEqualTo CompareOperator = "isNumberEqualTo"
 	// CompareOperatorIsEqualTo is a CompareOperator of type isEqualTo.
@@ -194,6 +196,7 @@ var _CompareOperatorNames = []string{
 	string(CompareOperatorDoesNotBeginWith),
 	string(CompareOperatorContains),
 	string(CompareOperatorDoesNotContain),
+	string(CompareOperatorTextContains),
 	string(CompareOperatorIsNumberEqualTo),
 	string(CompareOperatorIsEqualTo),
 	string(CompareOperatorIsIpEqualTo),
@@ -243,6 +246,7 @@ var _CompareOperatorValue = map[string]CompareOperator{
 	"doesNotBeginWith":               CompareOperatorDoesNotBeginWith,
 	"contains":                       CompareOperatorContains,
 	"doesNotContain":                 CompareOperatorDoesNotContain,
+	"textContains":                   CompareOperatorTextContains,
 	"isNumberEqualTo":                CompareOperatorIsNumberEqualTo,
 	"isEqualTo":                      CompareOperatorIsEqualTo,
 	"isIpEqualTo":                    CompareOperatorIsIpEqualTo,


### PR DESCRIPTION
## What

Add text contains operator (full text search) to openSearch query builder.

100% of the search terms have to appear in the document.

## Why

We want to be able to search string field which are of type `text` in the index mapping. So far we could only operate on `keyword` fields. It should not match in which order the search terms in the `text` appear, but they should all be present.

## References

- [Match Query Docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-match-query.html)
- Preparation for [VTI-399 - Improve search for CSAF documents](https://jira.greenbone.net/browse/VTI-399)

## Checklist

- [x] Tests


