### PR TITLE
Omit empty keys field RequestField struct

### DIFF
--- a/pkg/openSearch/openSearchClient/diskSpace.go
+++ b/pkg/openSearch/openSearchClient/diskSpace.go
@@ -14,7 +14,6 @@ import (
 
 type OpenSearchHealth struct {
 	openSearchProjectClient *opensearchapi.Client
-	context                 context.Context
 }
 
 func NewOpenSearchHealth(openSearchProjectClient *opensearchapi.Client) *OpenSearchHealth {
@@ -28,7 +27,7 @@ func (h *OpenSearchHealth) GetDiskAllocationPercentage() (int, error) {
 			Pretty: true,
 		},
 	}
-	allocation, err := h.openSearchProjectClient.Cat.Allocation(h.context, &request)
+	allocation, err := h.openSearchProjectClient.Cat.Allocation(context.Background(), &request)
 	if err != nil {
 		return 0, err
 	}
@@ -43,7 +42,7 @@ func (h *OpenSearchHealth) GetIndexesWithCreationDate(pattern string) ([]IndexIn
 			H: []string{"index,creation.date"},
 		},
 	}
-	response, err := h.openSearchProjectClient.Cat.Indices(h.context, &request)
+	response, err := h.openSearchProjectClient.Cat.Indices(context.Background(), &request)
 	if err != nil {
 		log.Debug().Err(err).Msg("error while checking if index exists")
 		return nil, err

--- a/pkg/query/filter/request.go
+++ b/pkg/query/filter/request.go
@@ -48,7 +48,7 @@ type RequestOptionType struct {
 // Field Value: The value of the field, which can be a list of values or a single value
 type RequestField struct {
 	Name     string          `json:"name" binding:"required"`
-	Keys     []string        `json:"keys"`
+	Keys     []string        `json:"keys,omitempty"`
 	Operator CompareOperator `json:"operator" binding:"required"`
 	// Value can be a list of values or a value
 	Value any `json:"value" binding:"required"`


### PR DESCRIPTION
## What

- do not add empty keys field to RequestField JSON
- also minor cleanup: context field in OpenSearchHealth struct is never initialized, so remove it for clarity

## Why

- empty fields are added for each filter field when marshaling from struct to JSON. Since we are passing the base64 encoded filter as URL parameter, we want to keep it as short as possible.

## References

https://jira.greenbone.net/browse/AT-2105

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


