### PR TITLE
update go version to `1.24.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/greenbone/opensight-golang-libraries
 
-go 1.23.5
+go 1.24.1
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## What

Update go version to `1.24.1`

## Why

A dependency requires a more recent go version than we use, see dependabot PR #180 


