### PR TITLE
Fix doesNotBeginWith Operator handler to handle multiple values

### DIFF
--- a/pkg/openSearch/openSearchQuery/compareHandler.go
+++ b/pkg/openSearch/openSearchQuery/compareHandler.go
@@ -137,7 +137,7 @@ func HandleCompareOperatorNotBeginsWith(fieldName string, fieldKeys []string, fi
 				})...,
 			)
 	} else { // for single values
-		return esquery.Prefix(fieldName+".keyword", fieldValue.(string))
+		return esquery.Prefix(fieldName+".keyword", ValueToString(fieldValue))
 	}
 }
 

--- a/pkg/openSearch/openSearchQuery/compareHandler_test.go
+++ b/pkg/openSearch/openSearchQuery/compareHandler_test.go
@@ -273,3 +273,47 @@ func TestHandleCompareOperatorTextContains(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleCompareOperatorBeginsWith(t *testing.T) {
+	field := "testField"
+
+	tests := []struct {
+		name     string
+		value    any
+		expected esquery.Mappable
+	}{
+		{
+			name:     "SingleValue",
+			value:    "test",
+			expected: esquery.Prefix(field, "test"),
+		},
+		{
+			name:  "MultipleValues",
+			value: []any{"test1", "test2"},
+			expected: esquery.Bool().
+				Should(
+					esquery.Prefix(field, "test1"),
+					esquery.Prefix(field, "test2"),
+				).
+				MinimumShouldMatch(1),
+		},
+		{
+			name:     "EmptyValue",
+			value:    "",
+			expected: esquery.Prefix(field, ""),
+		},
+		{
+			name:  "EmptySlice",
+			value: []any{},
+			expected: esquery.Bool().
+				Should().
+				MinimumShouldMatch(1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, handleCompareOperatorBeginsWith(field, tt.value))
+		})
+	}
+}


### PR DESCRIPTION
## What
Fix doesNotBeginWith Operator handler to handle multiple values

## Why
It breaks when we provide multiple entries using resultSelector

## References
https://jira.greenbone.net/browse/AT-2329

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


