### PR TITLE
Added: missing bucket option added for fields which can have null values

### DIFF
--- a/pkg/openSearch/esextension/termsSource.go
+++ b/pkg/openSearch/esextension/termsSource.go
@@ -6,9 +6,10 @@ package esextensions
 
 // TermsSource represents a terms value source in composite aggregations.
 type TermsSource struct {
-	name  string
-	field string
-	order string // Add order field for sorting
+	name          string
+	field         string
+	order         string // Add order field for sorting
+	missingBucket bool
 }
 
 // Terms creates a new TermsSource.
@@ -17,10 +18,17 @@ type TermsSource struct {
 // field: The name of the field referenced.
 func Terms(name string, field string) *TermsSource {
 	return &TermsSource{
-		name:  name,
-		field: field,
-		order: "asc", // Default order is ascending
+		name:          name,
+		field:         field,
+		order:         "asc", // Default order is ascending
+		missingBucket: false,
 	}
+}
+
+// MissingBucket sets the missing_bucket flag to true in the TermsSource.
+func (t *TermsSource) MissingBucket() *TermsSource {
+	t.missingBucket = true
+	return t
 }
 
 // Order sets the sorting order for the TermsSource.
@@ -38,6 +46,10 @@ func (t *TermsSource) Map() map[string]interface{} {
 
 	if t.order != "" {
 		termsMap["order"] = t.order
+	}
+
+	if t.missingBucket {
+		termsMap["missing_bucket"] = true
 	}
 
 	return map[string]interface{}{


### PR DESCRIPTION
## What
within the opensearch query we need to add the option "missing_bucket" as otherwise null values are not correctly reported 

## Why
EPSSScore can have null values 
