### PR TITLE
Add codecov.yml with threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%


### PR DESCRIPTION
## What

Add codecov.yml config with arbitrary threshold.

## Why

We want to allow some fluctuations, but not too much, regarding lowering coverage, to not get triggered with CI fail all the time.

## References

VTI-672



