### PR TITLE
Ops: Make sure dependency updates are considered for release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     schedule:
       interval: weekly
       time: "04:00"
-    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "Deps"
     allow:
     - dependency-type: direct
     - dependency-type: indirect
@@ -18,6 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## What

Prefix dependency update commit messages with `Deps`

## Why

Ensures that dependency updates appear in release notes.